### PR TITLE
Fix: allow resubmission of returned projects

### DIFF
--- a/app/api/projects/[id]/submit/route.ts
+++ b/app/api/projects/[id]/submit/route.ts
@@ -51,7 +51,7 @@ export async function POST(
 
   if (stage === "design") {
     // Design stage submission
-    if (project.designStatus !== "draft" && project.designStatus !== "rejected") {
+    if (project.designStatus !== "draft" && project.designStatus !== "rejected" && project.designStatus !== "update_requested") {
       return NextResponse.json(
         { error: "Design already submitted for review" },
         { status: 400 }

--- a/app/dashboard/projects/[id]/page.tsx
+++ b/app/dashboard/projects/[id]/page.tsx
@@ -449,7 +449,7 @@ export default function ProjectPage({ params }: { params: Promise<{ id: string }
   const buildSessions = project?.workSessions.filter(s => s.stage === "BUILD") ?? [];
   
   const canSubmitDesign = project &&
-    (project.designStatus === "draft" || project.designStatus === "rejected") &&
+    (project.designStatus === "draft" || project.designStatus === "rejected" || project.designStatus === "update_requested") &&
     project.description?.trim() &&
     (project.bomItems.length > 0 || project.noBomNeeded) &&
     (project.noBomNeeded || project.bomItems.length === 0 || project.cartScreenshots.length > 0) &&
@@ -466,7 +466,7 @@ export default function ProjectPage({ params }: { params: Promise<{ id: string }
     
   const canSubmitBuild = project &&
     project.designStatus === "approved" &&
-    (project.buildStatus === "draft" || project.buildStatus === "rejected" || project.buildStatus === "approved") &&
+    (project.buildStatus === "draft" || project.buildStatus === "rejected" || project.buildStatus === "approved" || project.buildStatus === "update_requested") &&
     buildSessions.length > 0 &&
     hasNewBuildSessions &&
     isVerified &&


### PR DESCRIPTION
## Summary
- When a reviewer "returns" a project (chooses RETURNED, not REJECTED), the project status becomes `update_requested`
- The submit button conditions (`canSubmitDesign`, `canSubmitBuild`) and the design submission API did not include `update_requested` as a valid status for resubmission
- Users were stuck unable to resubmit after making the requested changes

## Changes
- Added `update_requested` to `canSubmitDesign` and `canSubmitBuild` UI conditions in the project page
- Added `update_requested` to the design submission API guard (build API already allowed it)

## Test plan
- [ ] Return a design submission as a reviewer (choose "Return" not "Reject")
- [ ] As the project owner, verify the submit button is enabled and resubmission works
- [ ] Repeat for build submissions
- [ ] Verify permanently rejected projects can still be resubmitted (existing behavior)
- [ ] Verify in-review projects still cannot be double-submitted

🤖 Generated with [Claude Code](https://claude.com/claude-code)