### PR TITLE
Update starter-projects.ts

### DIFF
--- a/lib/starter-projects.ts
+++ b/lib/starter-projects.ts
@@ -6,7 +6,7 @@ const TIER_MAP: Record<string, number> = {
   'squeak': 1,
   'spotify-display': 1,
   'devboard': 2,
-  'split-keyboard': 2,
+  'split-keyboard': 3,
   'pathfinder': 1,
   'hermes': 1,
 };


### PR DESCRIPTION
The split-keyboard is tier 3 according to the guidelines, while here it shows as tier 2. Which is a misguidance and confusion. Im changing the hard coded tier file so it updates accordingly.