### PR TITLE
Update desc of Internal Notes field

### DIFF
--- a/app/admin/review/[id]/page.tsx
+++ b/app/admin/review/[id]/page.tsx
@@ -1160,7 +1160,7 @@ export default function ReviewDetailPage() {
       {/* ── Internal Notes Card ── */}
       <div className="bg-brown-800 border border-cream-500/20 rounded p-6">
         <h2 className="text-cream-50 text-sm uppercase tracking-wider mb-2">
-          Internal Notes <span className="text-cream-200 normal-case">(about this author, shared across reviewers)</span>
+          Internal Notes <span className="text-cream-200 normal-case">(about this author, shared across reviewers and projects)</span>
         </h2>
         <textarea
           value={internalNote}

--- a/app/reviews/[id]/page.tsx
+++ b/app/reviews/[id]/page.tsx
@@ -750,7 +750,7 @@ export default function ReviewDetailPage() {
       {/* ── Internal Notes Card ── */}
       <div className="bg-cream-100 border-2 border-cream-400 p-6">
         <h2 className="text-brown-800 text-sm uppercase tracking-wider mb-2">
-          Internal Notes <span className="text-cream-600 normal-case">(about this author, shared across reviewers)</span>
+          Internal Notes <span className="text-cream-600 normal-case">(about this author, shared across reviewers and projects)</span>
         </h2>
         <textarea
           value={internalNote}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -712,7 +712,7 @@ model ReviewClaim {
   @@map("review_claim")
 }
 
-// Internal notes about a user, shared across reviewers
+// Internal notes about a user, shared across reviewers and projects
 model ReviewerNote {
   id          String   @id @default(cuid())
   aboutUserId String   @unique


### PR DESCRIPTION
Updated it to "shared across reviewers and projects", where I added the "and projects" part to clearly indicate that that field is not just for one project.